### PR TITLE
Reduce margins

### DIFF
--- a/Google Docs.css
+++ b/Google Docs.css
@@ -69,7 +69,7 @@ video {
 }
 
 p {
-	margin: 0 0 1.5em;
+	margin: 0 0;
 }
 
 a:focus, a:hover {
@@ -113,7 +113,7 @@ li ul, li ol {
 }
 
 ul, ol {
-	margin:       0 3em 1.5em 1.5em;
+	margin:       0 3em 0.5em 0.5em;
 	padding-left: 1.5em;
 }
 
@@ -155,7 +155,7 @@ h1 + hr {
 
 ol#footnotes {
 	font-size:   0.75em;
-	padding-top: 1.5em;
+	padding-top: 0.5em;
 	margin-top:  3em;
 	margin-left: 0;
 }


### PR DESCRIPTION
# What does this PR do?

This reduces the margins as Google Docs was making them quite large. 

Here's a screenshot of a sample doc before this change:

![Screen Shot 2020-01-17 at 11 32 54 AM](https://user-images.githubusercontent.com/967/72628921-51f3fa00-391d-11ea-9ca8-a6d94fb4cc9b.png)

Here's a screenshot of a sample doc after this change:

![Screen Shot 2020-01-17 at 11 49 56 AM](https://user-images.githubusercontent.com/967/72630171-c92a8d80-391f-11ea-98b5-6a30f267cd6d.png)

This change makes the preview in Ulysses look worse, but the result when pasted into Google Docs looks much better.